### PR TITLE
AS-612: provide a base style reset to homogenize the browser styles

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -4,12 +4,16 @@ files:
 # see https://github.com/sasstools/sass-lint/tree/master/docs/rules
 rules:
   class-name-format: 0
+  force-attribute-nesting: 0
   force-element-nesting: 0
   force-pseudo-nesting: 0
   leading-zero: 0
   nesting-depth: 0
   no-color-literals: 0
+  no-css-comments: 0
   no-important: 0
+  no-qualifying-elements: 0
+  no-vendor-prefixes: 0
   property-sort-order: 0
   single-line-per-selector: 0
   variable-name-format: 0

--- a/assets/styles/_colours.scss
+++ b/assets/styles/_colours.scss
@@ -11,3 +11,11 @@ $purple: $ho-brand;
 $dark-grey: #3b3b3b;
 $mid-grey: #dadada;
 $light-grey: $background;
+$ho-focus: #ffbf47;
+
+// link colours
+$ho-link: $blue;
+$ho-link-visited: #4c2c92;
+$ho-link-hover: #2b8cc4;
+$ho-link-active: #2b8cc4;
+$ho-link-focus: #005798;

--- a/assets/styles/_default.scss
+++ b/assets/styles/_default.scss
@@ -1,10 +1,3 @@
-
-// Inter UI and style overrides
-
-.nta-font {
-  font-family: 'nta', Arial, sans-serif !important;
-}
-
 header, footer {
   background-color: $white;
 }
@@ -12,12 +5,6 @@ header, footer {
 main, .heading-section, .heading-xlarge, .heading-large, .heading-medium, .heading-small, .lede, .navbar, table td, .navbar .navbar__list-items li a {
   font-family: 'Inter UI', sans-serif;
   line-height: 1.45 !important;
-}
-
-body {
-  font-family: 'Inter UI', sans-serif;
-  line-height: 1.45 !important;
-  background-color: $background;
 }
 
 main, table td, .navbar .navbar__list-items li a {
@@ -29,8 +16,15 @@ main, table td, .navbar .navbar__list-items li a {
   margin-bottom: 1.5em;
 }
 
-@media (max-width: 640px) {
+input:focus,
+textarea:focus,
+select:focus,
+button:focus {
+  outline: 3px solid $ho-focus;
+  outline-offset: 0;
+}
 
+@include govuk-media-query($from: tablet) {
   body, main, .heading-section, .heading-xlarge, .heading-large, .heading-medium, .heading-small, .lede, .navbar, table td, .navbar .navbar__list-items li a {
     line-height: 1.35 !important;
   }

--- a/assets/styles/_default.scss
+++ b/assets/styles/_default.scss
@@ -24,7 +24,7 @@ button:focus {
   outline-offset: 0;
 }
 
-@include govuk-media-query($from: tablet) {
+@include govuk-media-query($until: tablet) {
   body, main, .heading-section, .heading-xlarge, .heading-large, .heading-medium, .heading-small, .lede, .navbar, table td, .navbar .navbar__list-items li a {
     line-height: 1.35 !important;
   }

--- a/assets/styles/_links.scss
+++ b/assets/styles/_links.scss
@@ -1,0 +1,30 @@
+a:link {
+  color: $ho-link;
+}
+
+a:visited {
+  color: $ho-link-visited;
+}
+
+a:hover {
+  color: $ho-link-hover;
+}
+
+a:active {
+  color: $ho-link-active;
+}
+
+/* Give a strong clear visual idea as to what is currently in focus */
+a {
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.3);
+}
+
+a:focus {
+  background-color: $ho-focus;
+  outline: 3px solid $ho-focus;
+}
+
+/* Make links slightly darker when focused to improve contrast. */
+a:link:focus {
+  color: $ho-link-focus;
+}

--- a/assets/styles/_reset.scss
+++ b/assets/styles/_reset.scss
@@ -1,0 +1,124 @@
+/*
+ * This reset originates from `govuk_template_mustache`, but has had irrelevant parts removed:
+ * https://github.com/alphagov/govuk_template_mustache/blob/916b68135a2e83beff8db46c3c097563d278d9ef/assets/stylesheets/govuk-template.css
+ */
+
+html,
+body,
+div,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+article,
+aside,
+footer,
+header,
+hgroup,
+nav,
+section,
+ol,
+ul,
+li,
+dl,
+dt,
+dd,
+blockquote,
+figure,
+fieldset,
+legend,
+textarea,
+pre,
+iframe {
+  margin: 0;
+  padding: 0;
+  vertical-align: baseline;
+}
+
+main {
+  display: block;
+}
+
+/*
+ * 1. Prevents iOS text size adjust after orientation change, without disabling
+ *    user zoom.
+ * 2. Force the scrollbar to always display in IE10/11
+ * 3. Corrects text resizing oddly in IE6/7 when body font-size is set using em units
+ *    http://clagnut.com/blog/348/#c790
+ *    note - font-size reduced to 62.5% to allow simple rem/px font-sizing and fallback
+ *    http://snook.ca/archives/html_and_css/font-size-with-rem
+ * 4. Keeps page centred in all browsers regardless of content height
+ * 5. Removes Android and iOS tap highlight color to prevent entire container being highlighted
+ *    www.yuiblog.com/blog/2010/10/01/quick-tip-customizing-the-mobile-safari-tap-highlight-color/
+ */
+ html {
+  -webkit-text-size-adjust: 100%;
+  /* 1 */
+  -ms-text-size-adjust: 100%;
+  /* 1 */
+  -ms-overflow-style: scrollbar;
+  /* 2 */
+  font-size: 62.5%;
+  /* 3 */
+  overflow-y: scroll;
+  /* 4 */
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  /* 5 */
+}
+
+/*
+ * 1. Font-size increased to compensate for change to html element font-size in
+ *    order to support beta typography which was set in ems
+ *    (62.5% * 160% = 100%)
+ */
+ body {
+  font-size: 160%;
+  /* 1 */
+}
+
+ol, ul, nav ol, nav ul {
+  list-style: inherit;
+}
+
+fieldset {
+  border: none;
+  padding: 0;
+}
+
+b,
+strong {
+  font-weight: 600;
+}
+
+img {
+  border: 0;
+}
+
+abbr[title] {
+  cursor: help;
+}
+
+/*
+ * 1. Addresses `appearance` set to `searchfield` in Safari 5 and Chrome.
+ * 2. Addresses `box-sizing` set to `border-box` in Safari 5 and Chrome
+ *    (include `-moz` to future-proof).
+ */
+input[type="search"] {
+  -webkit-appearance: textfield;
+  /* 1 */
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  /* 2 */
+  box-sizing: content-box;
+}
+
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: searchfield-cancel-button;
+  margin-right: 2px;
+}
+
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}

--- a/assets/styles/_reset.scss
+++ b/assets/styles/_reset.scss
@@ -53,7 +53,7 @@ main {
  * 5. Removes Android and iOS tap highlight color to prevent entire container being highlighted
  *    www.yuiblog.com/blog/2010/10/01/quick-tip-customizing-the-mobile-safari-tap-highlight-color/
  */
- html {
+html {
   -webkit-text-size-adjust: 100%;
   /* 1 */
   -ms-text-size-adjust: 100%;
@@ -73,7 +73,7 @@ main {
  *    order to support beta typography which was set in ems
  *    (62.5% * 160% = 100%)
  */
- body {
+body {
   font-size: 160%;
   /* 1 */
 }
@@ -83,7 +83,7 @@ ol, ul, nav ol, nav ul {
 }
 
 fieldset {
-  border: none;
+  border: 0;
   padding: 0;
 }
 
@@ -105,7 +105,7 @@ abbr[title] {
  * 2. Addresses `box-sizing` set to `border-box` in Safari 5 and Chrome
  *    (include `-moz` to future-proof).
  */
-input[type="search"] {
+input[type='search'] {
   -webkit-appearance: textfield;
   /* 1 */
   -moz-box-sizing: content-box;
@@ -114,11 +114,11 @@ input[type="search"] {
   box-sizing: content-box;
 }
 
-input[type="search"]::-webkit-search-cancel-button {
+input[type='search']::-webkit-search-cancel-button {
   -webkit-appearance: searchfield-cancel-button;
   margin-right: 2px;
 }
 
-input[type="search"]::-webkit-search-decoration {
+input[type='search']::-webkit-search-decoration {
   -webkit-appearance: none;
 }

--- a/assets/styles/_typography.scss
+++ b/assets/styles/_typography.scss
@@ -3,7 +3,7 @@ $govuk-font-family: 'Inter UI', sans-serif !default;
 body {
   background-color: $background;
   color: $black;
-  line-height: 1.45 !important;
+  line-height: 1.45;
   font-family: $govuk-font-family;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;

--- a/assets/styles/_typography.scss
+++ b/assets/styles/_typography.scss
@@ -1,9 +1,19 @@
+body {
+  background-color: $background;
+  color: $black;
+  line-height: 1.45 !important;
+  font-family: 'Inter UI', sans-serif;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
 .quote {
   font-style: italic;
   margin-left: 40px;
 }
 
-@media (max-width: 640px) {
+@include govuk-media-query($from: tablet) {
   .quote {
     margin-left: 10px;
   }
@@ -30,4 +40,3 @@
   font-size: 18px;
   line-height: 1.45;
 }
-

--- a/assets/styles/_typography.scss
+++ b/assets/styles/_typography.scss
@@ -15,7 +15,7 @@ body {
   margin-left: 40px;
 }
 
-@include govuk-media-query($from: tablet) {
+@include govuk-media-query($until: tablet) {
   .quote {
     margin-left: 10px;
   }

--- a/assets/styles/_typography.scss
+++ b/assets/styles/_typography.scss
@@ -1,8 +1,10 @@
+$govuk-font-family: 'Inter UI', sans-serif !default;
+
 body {
   background-color: $background;
   color: $black;
   line-height: 1.45 !important;
-  font-family: 'Inter UI', sans-serif;
+  font-family: $govuk-font-family;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,9 +1,11 @@
+@import 'reset';
 @import 'govuk-frontend';
 
 @import 'colours';
 @import 'default';
 @import 'fonts';
 @import 'typography';
+@import 'links';
 
 @import 'components/header';
 @import 'components/footer';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "styles": "./assets/styles/index.scss",
   "scripts": {
     "test": "npm run test:lint",
-    "test:lint": "sass-lint --no-exit --verbose"
+    "test:lint": "sass-lint --max-warnings=0 --no-exit --verbose"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
asl-pages was using a style reset brought in from https://github.com/alphagov/govuk_template_mustache/blob/916b68135a2e83beff8db46c3c097563d278d9ef/assets/stylesheets/govuk-template.css

We need to provide a similar reset but with any irrelevant stuff removed.