### PR TITLE
AS-638: make sure h2s in links inherit the link state colour

### DIFF
--- a/assets/styles/_links.scss
+++ b/assets/styles/_links.scss
@@ -1,17 +1,33 @@
 a:link {
   color: $ho-link;
+
+  h2 {
+    color: $ho-link;
+  }
 }
 
 a:visited {
   color: $ho-link-visited;
+
+  h2 {
+    color: $ho-link-visited;
+  }
 }
 
 a:hover {
   color: $ho-link-hover;
+
+  h2 {
+    color: $ho-link-hover;
+  }
 }
 
 a:active {
   color: $ho-link-active;
+
+  h2 {
+    color: $ho-link-active;
+  }
 }
 
 /* Give a strong clear visual idea as to what is currently in focus */


### PR DESCRIPTION
H2s inside of links were setting the text colour back to black, but we actually want them to follow the link state colours.