### PR TITLE
Ensure hidden panels are hidden

### DIFF
--- a/assets/styles/components/_checkboxes.scss
+++ b/assets/styles/components/_checkboxes.scss
@@ -4,4 +4,8 @@
 .govuk-checkboxes__item > .govuk-reveal {
   margin-top: $govuk-gutter / 2;
   margin-left: -24px;
+
+  &.hidden {
+    display: none;
+  }
 }

--- a/assets/styles/components/_radios.scss
+++ b/assets/styles/components/_radios.scss
@@ -4,4 +4,8 @@
 .govuk-radios__item > .govuk-reveal {
   margin-top: $govuk-gutter / 2;
   margin-left: -24px;
+
+  &.hidden {
+    display: none;
+  }
 }


### PR DESCRIPTION
Currently the styling for the `.hidden` class is only applied at a project implementation level, which seems weird.

If a reveal panel has a `.hidden` class then hide it.