### PR TITLE
Remove margin-bottom from radio/checkbox groups as it's doubled up by govuk-form-group

### DIFF
--- a/assets/styles/components/_fieldset.scss
+++ b/assets/styles/components/_fieldset.scss
@@ -19,7 +19,6 @@
 
   .govuk-radios, .govuk-checkboxes {
     margin-top: $govuk-gutter-half;
-    margin-bottom: $govuk-gutter;
   }
 }
 


### PR DESCRIPTION
All of our radio and checkbox groups are wrapped in `.govuk-form-group` div by default, resulting in 2x `$govuk-gutter` being applied to the bottom margin.